### PR TITLE
Trend bisplit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # 0.53
-
+-   fixed bug in plot argument `lines = "trendA_bisplit"`
 *New functions:*  
 - `is.scdf`: Tests if an object is of type "scdf" or not.
 

--- a/R/plot.scdf.R
+++ b/R/plot.scdf.R
@@ -30,7 +30,7 @@
 #' \code{lines = list(mean = 0.2)} draws a 20\%-trimmed mean line).
 #' \item\code{"trend"} Separate lines for phase A and B trends.
 #' \item\code{"trendA"} OLS trend line for phase A, extrapolated throughout phase B.
-#' \item\code{"trendA_sm"} Split middle trend line for phase A, extrapolated throughout phase B.
+#' \item\code{"trendA_bisplit"} Split middle (bi-split) trend line for phase A, extrapolated throughout phase B.
 #' \item\code{"maxA/minA"} Line at the level of the highest or lowest phase A score.
 #' \item\code{"medianA"} Line at the phase A median score.  \item\code{"meanA"}
 #' Line at the phase A 10\%-trimmed mean score. Apply a different trim, by
@@ -515,15 +515,15 @@ plotSC <- function(data, dvar, pvar, mvar, ylim = NULL, xlim = NULL, xinc = 1, l
         reg <- lm(y~x)
         lines(c(min(x), maxMT), c(reg$coefficients[1]  + min(x) * reg$coefficients[2], reg$coefficients[1] + maxMT * reg$coefficients[2]), lty = lty.line, col = col.line, lwd = lwd.line)
       }
-      if (any(names(lines) == "trendA_sm")) {
+      if (any(names(lines) == "trendA_bisplit")) {
         x     <- data[design$start[1]:design$stop[1],mvar]
         y     <- data[design$start[1]:design$stop[1],dvar]
         maxMT <- max(data[,mvar])
         # na.rm = FALSE for now to prevent misuse; will draw no line if NA present
-        md1   <- c((median(y[1:(length(y)/2)], na.rm = FALSE)),
-                   median(x[1:(length(x)/2)], na.rm = FALSE))
-        md2   <- c((median(y[(length(y)/2+1):length(y)], na.rm = FALSE)),
-                   median(x[(length(x)/2+1):length(x)], na.rm = FALSE))
+        md1   <- c((median(y[1:floor(length(y)/2)], na.rm = FALSE)),
+                   median(x[1:floor(length(x)/2)], na.rm = FALSE))
+        md2   <- c((median(y[ceiling(length(y)/2+1):length(y)], na.rm = FALSE)),
+                   median(x[ceiling(length(x)/2+1):length(x)], na.rm = FALSE))
         md    <- rbind(md1, md2)
         reg <- lm(md[,1]~md[,2])
         lines(c(min(x), maxMT), c(reg$coefficients[1]  + min(x) * reg$coefficients[2], reg$coefficients[1] + maxMT * reg$coefficients[2]), lty = lty.line, col = col.line, lwd = lwd.line)


### PR DESCRIPTION
Fixed a rounding error in split middle technique trend line for odd baseline halfs.
Renamed lines argument ("trendA_bisplit") to better distinguish from other methods (e.g. tri-split) in the future.